### PR TITLE
Match OpsGenie's API a bit better

### DIFF
--- a/src/sentry_opsgenie/plugin.py
+++ b/src/sentry_opsgenie/plugin.py
@@ -69,10 +69,11 @@ class OpsGeniePlugin(notify.NotificationPlugin):
     def build_payload(self, group, event):
         payload = {
             'message': event.message,
-            'alias': getattr(group, 'message_short', group.message).encode('utf-8'),
+            'alias': 'sentry: %d' % group.id,
             'source': 'Sentry',
             'details': {
                 'Sentry ID': str(group.id),
+                'Sentry Group': getattr(group, 'message_short', group.message).encode('utf-8'),
                 'Checksum': group.checksum,
                 'Project ID': group.project.slug,
                 'Project Name': group.project.name,
@@ -92,7 +93,7 @@ class OpsGeniePlugin(notify.NotificationPlugin):
         if not self.is_configured(group.project):
             return
 
-        api_key = self.get_option('api_key', group.project)
+        api_key = self.get_option('apiKey', group.project)
         recipients = self.get_option('recipients', group.project)
         alert_url = self.get_option('alert_url', group.project)
 


### PR DESCRIPTION
* Pass the group message as OpsGenie's `alias` field, so that OpsGenie groups events consistently with Sentry
* The individual event's message is passed via `message`, for folk that want individual errors as well
* The group's culprit is passed via `entity`
* `details` fields are Title Cased so that they display consistently in OpsGenie's UI w/ other fields