### PR TITLE
README updated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,12 @@ Install the package via ``pip``::
 
     pip install sentry-opsgenie
 
+
+### Sentry >= 9.0
+You will have to install the package via Git:
+
+```
+pip install https://github.com/getsentry/sentry-opsgenie/archive/master.zip
+```
+
 You can now configure alerts via the plugin configuration panel within your project.


### PR DESCRIPTION
I've updated the README to reflect the requirement that `sentry-opsgenie` be installed from `https://github.com/getsentry/sentry-opsgenie/archive/master.zip` in order to work correctly with Sentry >= 9.0.